### PR TITLE
feat: enforcement hook — blocks code edits without a spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Enforcement hook** (`pre-tool-use`) — mechanically blocks Write/Edit on source code when no spec exists in `specs/`. The Code Rule is no longer advisory-only for Claude Code users.
 - Delta and Refactor example specs in `advanced/examples/` (real production specs, anonymized)
 - `hooks/README.md` — documents what each hook does, how to verify, how to disable
 - `CONTRIBUTING.md` — guide for community contributions
@@ -14,6 +15,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - GitHub issue templates (bug report + feature request)
 
 ### Changed
+- `snippet.md` — Code Rule section now documents mechanical enforcement
+- `install.sh` / `install.ps1` — register `PreToolUse` enforcement hook with `matcher: "Edit|Write"`
 - `tool-matrix.md` — added stack disclaimer (methodology is stack-agnostic, tool recommendations are JS/TS-specific)
 
 ## [2026-03-30]

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ The same data determines when human review is required — and when autonomous i
 | [`spec.md`](spec.md) | Spec template — full S1–S6, Delta, and Bug formats. |
 | [`review.md`](review.md) | Two-pass code review checklist. |
 | [`install.sh`](install.sh) | Auto-detect + append installer. |
+| [`hooks/`](hooks/) | Enforcement hook (blocks code without spec) + session lifecycle hooks. Claude Code only. |
 | [`advanced/examples/`](advanced/examples/) | Real production specs (anonymized) — feature, bug fix, delta, and refactor formats. |
 | [`advanced/`](advanced/) | Team workflow, calibration protocol, /spec /spec-review /spec-check /spec-stats skills. |
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,6 @@
-# Hooks — Session Lifecycle Automation
+# Hooks — Lifecycle Automation + Enforcement
 
-Optional automation for Claude Code users. These hooks inject context at key moments in the AI session lifecycle so the methodology stays active without manual reminders.
+Hooks for Claude Code users. Lifecycle hooks inject context at key session moments. The enforcement hook mechanically blocks code edits without a spec.
 
 **Not using Claude Code?** These hooks are Claude Code-specific. For other tools, see [INTEGRATIONS.md](../advanced/INTEGRATIONS.md).
 
@@ -8,30 +8,68 @@ Optional automation for Claude Code users. These hooks inject context at key mom
 
 ## Hook Reference
 
-| Hook | Fires when | What it injects |
-|------|-----------|-----------------|
-| `session-start` | New session opens | Spec-first reminder + `KNOWLEDGE.md` contents + `session-state.md` (if exists) |
-| `pre-compact` | Context is about to be compressed | Reminder to save learnings to `KNOWLEDGE.md` before old context is lost |
-| `session-end` | Session closes (Stop) | Prompt to update `KNOWLEDGE.md` + `session-state.md` with session results |
-| `run-hook.cmd` | *(wrapper)* | Polyglot bash/batch script — makes hooks work on both Unix and Windows |
+| Hook | Event | What it does |
+|------|-------|-------------|
+| `pre-tool-use` | Before Write/Edit | **Enforcement** — blocks source code edits when no spec exists in `specs/` |
+| `session-start` | New session opens | Injects spec-first reminder + `KNOWLEDGE.md` + `session-state.md` |
+| `pre-compact` | Context compaction | Reminds AI to save learnings to `KNOWLEDGE.md` before context is lost |
+| `session-end` | Session closes | Prompts AI to update `KNOWLEDGE.md` + `session-state.md` + spec status |
+| `run-hook.cmd` | *(wrapper)* | Polyglot bash/batch — makes hooks work on both Unix and Windows |
 
-### What each hook does
+---
 
-**`session-start`** — The most important hook. At every session start, it injects:
+## Enforcement Hook (`pre-tool-use`)
+
+The Code Rule says "never write code without a spec." This hook makes it mechanical.
+
+**How it works:**
+1. Claude Code calls this hook before every Write or Edit tool call
+2. Hook checks: is the file a source code file? (`.ts`, `.py`, `.go`, `.rs`, etc.)
+3. If yes: does `specs/` contain at least one active `.md` file?
+4. No active spec → **edit blocked** — AI receives instructions to write a spec first
+5. Spec exists → edit allowed
+
+**What's never blocked:**
+- Markdown, JSON, YAML, config files (any non-source-code extension)
+- Test files (any path containing `test`, `__tests__`, `__mocks__`, `.test.`, `.spec.`)
+- Spec files themselves (`specs/*.md`)
+- Files outside the project directory
+
+**Bypass mechanisms:**
+```bash
+# Temporary: create bypass file (remove it to re-enable)
+touch .spec-first-bypass
+
+# Per-session: environment variable
+export SPEC_FIRST_ENFORCEMENT=off
+```
+
+**What happens when blocked:**
+
+The AI receives a message explaining why the edit was blocked and what to do:
+1. Say "build [feature]" to write a full spec
+2. Run `/spec [slug]` to create one directly
+3. For emergencies: create `specs/[slug]-bug.md` (S1 + S6), then implement
+
+The enforcement teaches the correct workflow — the AI writes a spec, which satisfies the hook, then implements.
+
+---
+
+### Lifecycle Hooks
+
+**`session-start`** — At every session start, injects:
 1. A `<spec-first-active>` block reminding the AI to check for specs before writing code
 2. The full contents of `KNOWLEDGE.md` (project learnings from previous sessions)
 3. The contents of `.claude/session-state.md` (what the last session was working on)
 
-This ensures every session starts with methodology context + project memory — no manual copy-paste needed.
+**`pre-compact`** — When Claude Code compresses the conversation (context limit approaching), reminds the AI to save any discoveries to `KNOWLEDGE.md` before they're lost.
 
-**`pre-compact`** — When Claude Code compresses the conversation (context limit approaching), this hook reminds the AI to save any discoveries to `KNOWLEDGE.md` before they're lost. Without this, learnings from the first half of a long session disappear during compaction.
-
-**`session-end`** — When you close a session, this hook prompts the AI to:
+**`session-end`** — When you close a session, prompts the AI to:
 - Append non-obvious patterns to `KNOWLEDGE.md` (if they recurred 2+ times)
 - Update `.claude/session-state.md` with what was accomplished and what's next
 - Update the spec's YAML frontmatter status field
 
-**`run-hook.cmd`** — A polyglot file that works as both a bash script and a Windows batch file. On Unix, it directly executes the named hook script. On Windows, it finds `bash.exe` (Git for Windows, MSYS2, Cygwin, or WSL) and uses it to run the hook. If no bash is found, it exits silently — the tool still works, just without hook injection.
+**`run-hook.cmd`** — A polyglot file that works as both a bash script and a Windows batch file. On Unix, it directly executes the named hook script. On Windows, it finds `bash.exe` (Git for Windows, MSYS2, Cygwin, or WSL) and uses it to run the hook. If no bash is found, it exits silently.
 
 ---
 
@@ -39,7 +77,8 @@ This ensures every session starts with methodology context + project memory — 
 
 1. Open a new Claude Code session in your project
 2. The first AI response should contain awareness of spec-first methodology
-3. Check `.claude/settings.json` — you should see entries under `hooks.SessionStart`, `hooks.PreCompact`, and `hooks.Stop`
+3. Try editing a `.ts` file without a spec — the edit should be blocked
+4. Check `.claude/settings.json`:
 
 ```bash
 # Quick check: are hooks registered?
@@ -50,22 +89,29 @@ cat .claude/settings.json | grep -A2 "spec-first"
 
 ## How to Disable
 
-Remove the hook entries from `.claude/settings.json`:
+**Disable enforcement only:**
+```bash
+export SPEC_FIRST_ENFORCEMENT=off
+```
 
+**Disable all hooks** — remove entries from `.claude/settings.json`:
 ```json
 {
   "hooks": {
     "SessionStart": [],
     "PreCompact": [],
+    "PreToolUse": [],
     "Stop": []
   }
 }
 ```
 
-Or delete the `.claude/spec-first/` directory entirely. The core methodology (in your AI context file) still works without hooks — hooks are a convenience layer, not a requirement.
+Or delete the `.claude/spec-first/` directory entirely. The core methodology (in your AI context file) still works without hooks — hooks are a convenience layer, enforcement is a discipline layer.
 
 ---
 
 ## How Hooks Are Installed
 
 The installer (`install.sh` or `install.ps1`) copies hook scripts to `.claude/spec-first/` and registers them in `.claude/settings.json`. Registration is idempotent — running the installer twice won't create duplicate entries.
+
+The enforcement hook registers under `PreToolUse` with `matcher: "Edit|Write"` — it only fires for file modification tools, not for Read, Glob, Grep, or Bash.

--- a/hooks/pre-tool-use
+++ b/hooks/pre-tool-use
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# spec-first enforcement — PreToolUse hook
+# Blocks Write/Edit on source code files when no active spec exists in specs/.
+#
+# This is the mechanical enforcement of the Code Rule:
+#   "Never write code without reading a spec."
+#
+# How it works:
+#   1. Claude Code calls this before every Write/Edit tool call
+#   2. If the file is source code (.ts, .py, .go, etc.) — check specs/
+#   3. If no spec exists — block the edit (exit 2)
+#   4. Config, docs, markdown, test files — always allowed
+#
+# Disable: SPEC_FIRST_ENFORCEMENT=off or touch .spec-first-bypass
+# Installed to .claude/spec-first/ by install.sh
+
+set -euo pipefail
+
+# ── Quick exit if enforcement is disabled ─────────────────────────────────
+
+[ "${SPEC_FIRST_ENFORCEMENT:-}" = "off" ] && exit 0
+
+# ── Parse tool input from stdin ───────────────────────────────────────────
+# Claude Code pipes JSON: { tool_name, tool_input: { file_path }, cwd }
+
+INPUT=$(cat)
+
+FILE_PATH=""
+CWD=""
+
+if command -v jq &>/dev/null; then
+  FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+  CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
+elif command -v python3 &>/dev/null; then
+  PARSED=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('file_path', ''))
+    print(d.get('cwd', ''))
+except Exception:
+    print('')
+    print('')
+" 2>/dev/null) || true
+  FILE_PATH=$(echo "$PARSED" | sed -n '1p')
+  CWD=$(echo "$PARSED" | sed -n '2p')
+fi
+
+# Can't parse input — fail open (don't break the user's workflow)
+[ -z "$FILE_PATH" ] || [ -z "$CWD" ] && exit 0
+
+# ── Bypass file — temporary per-project override ─────────────────────────
+# Users can `touch .spec-first-bypass` to disable enforcement.
+# Remove the file to re-enable.
+
+[ -f "${CWD}/.spec-first-bypass" ] && exit 0
+
+# ── Get path relative to project root ─────────────────────────────────────
+
+REL_PATH="${FILE_PATH#${CWD}/}"
+
+# File outside project directory — allow
+[ "$REL_PATH" = "$FILE_PATH" ] && exit 0
+
+# ── Test files — always allowed (even source code extensions) ─────────────
+
+case "$REL_PATH" in
+  *test*|*__tests__*|*__mocks__*|*.test.*|*.spec.*) exit 0 ;;
+esac
+
+# ── Only enforce on source code files ─────────────────────────────────────
+# Everything NOT in this list is automatically allowed:
+# markdown, JSON, YAML, config, docs, lock files, images, etc.
+
+case "$REL_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs)  ;; # JavaScript / TypeScript
+  *.py|*.pyx)                          ;; # Python
+  *.go)                                ;; # Go
+  *.rs)                                ;; # Rust
+  *.java|*.kt|*.scala)                ;; # JVM
+  *.rb|*.erb)                          ;; # Ruby
+  *.php)                               ;; # PHP
+  *.cs)                                ;; # C#
+  *.swift)                             ;; # Swift
+  *.c|*.cpp|*.cc|*.h|*.hpp)           ;; # C / C++
+  *.vue|*.svelte)                      ;; # Framework SFC
+  *.dart)                              ;; # Dart
+  *.ex|*.exs)                          ;; # Elixir
+  *.lua)                               ;; # Lua
+  *.zig)                               ;; # Zig
+  *)  exit 0 ;;                          # Not source code — allow
+esac
+
+# ── Check for active specs in specs/ ──────────────────────────────────────
+# Active = any .md file directly in specs/ (not in specs/done/)
+# We don't parse YAML frontmatter — just check file existence for speed.
+
+SPECS_DIR="${CWD}/specs"
+
+if [ -d "$SPECS_DIR" ]; then
+  # Fast check: is there at least one .md file at top level?
+  if [ -n "$(find "$SPECS_DIR" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null)" ]; then
+    exit 0  # Active spec exists — allow
+  fi
+fi
+
+# ── No active spec — BLOCK ────────────────────────────────────────────────
+
+cat >&2 << BLOCK
+spec-first enforcement: no active spec found in specs/
+
+You are trying to edit: ${REL_PATH}
+Write a spec before implementing code:
+  1. Say "build [feature]" to write a full spec
+  2. Or run /spec [slug] to create one directly
+  3. Emergency fix? Create specs/[slug]-bug.md (S1 + S6), then implement
+
+Bypass: user runs "touch .spec-first-bypass" or set SPEC_FIRST_ENFORCEMENT=off
+BLOCK
+exit 2

--- a/install.ps1
+++ b/install.ps1
@@ -93,10 +93,11 @@ if ((Test-Path $claudeDir) -or ($CONTEXT_FILE -eq "CLAUDE.md")) {
     $hooksDir = Join-Path $claudeDir "spec-first"
     New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
 
-    (Invoke-WebRequest "$REPO/hooks/session-start" -UseBasicParsing).Content | Set-Content "$hooksDir\session-start" -Encoding UTF8
-    (Invoke-WebRequest "$REPO/hooks/pre-compact"   -UseBasicParsing).Content | Set-Content "$hooksDir\pre-compact"   -Encoding UTF8
-    (Invoke-WebRequest "$REPO/hooks/session-end"   -UseBasicParsing).Content | Set-Content "$hooksDir\session-end"   -Encoding UTF8
-    (Invoke-WebRequest "$REPO/hooks/run-hook.cmd"  -UseBasicParsing).Content | Set-Content "$hooksDir\run-hook.cmd"  -Encoding UTF8
+    (Invoke-WebRequest "$REPO/hooks/session-start"  -UseBasicParsing).Content | Set-Content "$hooksDir\session-start"  -Encoding UTF8
+    (Invoke-WebRequest "$REPO/hooks/pre-compact"    -UseBasicParsing).Content | Set-Content "$hooksDir\pre-compact"    -Encoding UTF8
+    (Invoke-WebRequest "$REPO/hooks/session-end"    -UseBasicParsing).Content | Set-Content "$hooksDir\session-end"    -Encoding UTF8
+    (Invoke-WebRequest "$REPO/hooks/pre-tool-use"   -UseBasicParsing).Content | Set-Content "$hooksDir\pre-tool-use"   -Encoding UTF8
+    (Invoke-WebRequest "$REPO/hooks/run-hook.cmd"   -UseBasicParsing).Content | Set-Content "$hooksDir\run-hook.cmd"   -Encoding UTF8
 
     # Register hooks in .claude/settings.json (merge safely)
     $settingsFile = Join-Path $claudeDir "settings.json"
@@ -107,6 +108,7 @@ if ((Test-Path $claudeDir) -or ($CONTEXT_FILE -eq "CLAUDE.md")) {
     }
     if (-not $settings.ContainsKey("hooks")) { $settings["hooks"] = @{} }
 
+    # Lifecycle hooks (no matcher)
     $hookEntries = @(
         @{ event = "SessionStart"; cmd = ".claude/spec-first/run-hook.cmd session-start" },
         @{ event = "PreCompact";   cmd = ".claude/spec-first/run-hook.cmd pre-compact" },
@@ -124,6 +126,20 @@ if ((Test-Path $claudeDir) -or ($CONTEXT_FILE -eq "CLAUDE.md")) {
         } else {
             Write-Host "[OK] $($entry.event) hook already registered (skipping)"
         }
+    }
+
+    # Enforcement hook (matcher: Write|Edit)
+    if (-not $settings["hooks"].ContainsKey("PreToolUse")) { $settings["hooks"]["PreToolUse"] = @() }
+    $enforceRegistered = $settings["hooks"]["PreToolUse"] | Where-Object { $_ -match "spec-first" }
+    if (-not $enforceRegistered) {
+        $settings["hooks"]["PreToolUse"] += @{
+            matcher = "Edit|Write"
+            hooks = @(@{ type = "command"; command = ".claude/spec-first/run-hook.cmd pre-tool-use" })
+        }
+        $changed = $true
+        Write-Host "[OK] PreToolUse enforcement hook registered (blocks code edits without a spec)"
+    } else {
+        Write-Host "[OK] PreToolUse enforcement hook already registered (skipping)"
     }
 
     if ($changed) {

--- a/install.sh
+++ b/install.sh
@@ -127,29 +127,33 @@ if [ -d "$CLAUDE_DIR" ] || [ "$CONTEXT_FILE" = "CLAUDE.md" ]; then
   mkdir -p "$CLAUDE_HOOKS"
 
   if [ "$LOCAL" = true ]; then
-    cp "$SCRIPT_DIR/hooks/session-start" "$CLAUDE_HOOKS/session-start"
-    cp "$SCRIPT_DIR/hooks/pre-compact"   "$CLAUDE_HOOKS/pre-compact"
-    cp "$SCRIPT_DIR/hooks/session-end"   "$CLAUDE_HOOKS/session-end"
-    cp "$SCRIPT_DIR/hooks/run-hook.cmd"  "$CLAUDE_HOOKS/run-hook.cmd"
+    cp "$SCRIPT_DIR/hooks/session-start"  "$CLAUDE_HOOKS/session-start"
+    cp "$SCRIPT_DIR/hooks/pre-compact"    "$CLAUDE_HOOKS/pre-compact"
+    cp "$SCRIPT_DIR/hooks/session-end"    "$CLAUDE_HOOKS/session-end"
+    cp "$SCRIPT_DIR/hooks/pre-tool-use"   "$CLAUDE_HOOKS/pre-tool-use"
+    cp "$SCRIPT_DIR/hooks/run-hook.cmd"   "$CLAUDE_HOOKS/run-hook.cmd"
   else
-    curl -fsSL "$REPO/hooks/session-start" -o "$CLAUDE_HOOKS/session-start"
-    curl -fsSL "$REPO/hooks/pre-compact"   -o "$CLAUDE_HOOKS/pre-compact"
-    curl -fsSL "$REPO/hooks/session-end"   -o "$CLAUDE_HOOKS/session-end"
-    curl -fsSL "$REPO/hooks/run-hook.cmd"  -o "$CLAUDE_HOOKS/run-hook.cmd"
+    curl -fsSL "$REPO/hooks/session-start"  -o "$CLAUDE_HOOKS/session-start"
+    curl -fsSL "$REPO/hooks/pre-compact"    -o "$CLAUDE_HOOKS/pre-compact"
+    curl -fsSL "$REPO/hooks/session-end"    -o "$CLAUDE_HOOKS/session-end"
+    curl -fsSL "$REPO/hooks/pre-tool-use"   -o "$CLAUDE_HOOKS/pre-tool-use"
+    curl -fsSL "$REPO/hooks/run-hook.cmd"   -o "$CLAUDE_HOOKS/run-hook.cmd"
   fi
-  chmod +x "$CLAUDE_HOOKS/session-start" "$CLAUDE_HOOKS/pre-compact" "$CLAUDE_HOOKS/session-end" "$CLAUDE_HOOKS/run-hook.cmd" 2>/dev/null || true
+  chmod +x "$CLAUDE_HOOKS/session-start" "$CLAUDE_HOOKS/pre-compact" "$CLAUDE_HOOKS/session-end" "$CLAUDE_HOOKS/pre-tool-use" "$CLAUDE_HOOKS/run-hook.cmd" 2>/dev/null || true
 
   # Register hooks in .claude/settings.json (merge safely with python3, fallback to create)
   SETTINGS_FILE="$CLAUDE_DIR/settings.json"
   HOOK_CMD=".claude/spec-first/run-hook.cmd session-start"
   HOOK_CMD_COMPACT=".claude/spec-first/run-hook.cmd pre-compact"
   HOOK_CMD_STOP=".claude/spec-first/run-hook.cmd session-end"
+  HOOK_CMD_ENFORCE=".claude/spec-first/run-hook.cmd pre-tool-use"
 
   if command -v python3 &>/dev/null; then
-    python3 - "$SETTINGS_FILE" "$HOOK_CMD" "$HOOK_CMD_COMPACT" "$HOOK_CMD_STOP" << 'PYEOF'
+    python3 - "$SETTINGS_FILE" "$HOOK_CMD" "$HOOK_CMD_COMPACT" "$HOOK_CMD_STOP" "$HOOK_CMD_ENFORCE" << 'PYEOF'
 import json, sys, os
 
-settings_path, hook_start, hook_compact, hook_stop = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+settings_path = sys.argv[1]
+hook_start, hook_compact, hook_stop, hook_enforce = sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
 settings = {}
 if os.path.exists(settings_path):
     try:
@@ -161,6 +165,7 @@ if os.path.exists(settings_path):
 hooks = settings.setdefault("hooks", {})
 changed = False
 
+# Lifecycle hooks (no matcher needed)
 for event, cmd in [("SessionStart", hook_start), ("PreCompact", hook_compact), ("Stop", hook_stop)]:
     entries = hooks.setdefault(event, [])
     if not any("spec-first" in str(h) for h in entries):
@@ -169,6 +174,18 @@ for event, cmd in [("SessionStart", hook_start), ("PreCompact", hook_compact), (
         print(f"✓ {event} hook registered in .claude/settings.json")
     else:
         print(f"✓ {event} hook already registered (skipping)")
+
+# Enforcement hook (matcher: Write|Edit only)
+pre_tool_entries = hooks.setdefault("PreToolUse", [])
+if not any("spec-first" in str(h) for h in pre_tool_entries):
+    pre_tool_entries.append({
+        "matcher": "Edit|Write",
+        "hooks": [{"type": "command", "command": hook_enforce}]
+    })
+    changed = True
+    print("✓ PreToolUse enforcement hook registered (blocks code edits without a spec)")
+else:
+    print("✓ PreToolUse enforcement hook already registered (skipping)")
 
 if changed:
     os.makedirs(os.path.dirname(settings_path), exist_ok=True)
@@ -190,11 +207,22 @@ PYEOF
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOOK_CMD_ENFORCE"
+          }
+        ]
+      }
     ]
   }
 }
 JSON
-      echo "✓ SessionStart hook registered in .claude/settings.json"
+      echo "✓ SessionStart + PreToolUse hooks registered in .claude/settings.json"
     else
       echo "  (python3 not found — add hooks manually to .claude/settings.json)"
       echo "  See: https://github.com/nlatuan187/spec-first/tree/master/hooks"

--- a/snippet.md
+++ b/snippet.md
@@ -271,6 +271,8 @@ Before writing implementation code: check if `specs/[slug].md` exists for this c
 
 *Derives from: The most probable next token after "implement this feature" is confident-sounding code that skips error states, misses integrations, and works only on the happy path. A spec overrides probability with specificity. This rule is read at session start and decays with conversation length — re-read it if context exceeds 40%.*
 
+**Mechanical enforcement** (Claude Code): The `pre-tool-use` hook blocks Write/Edit on source code when no spec exists in `specs/`. Config, docs, markdown, and test files are never blocked. Bypass: `touch .spec-first-bypass` or `SPEC_FIRST_ENFORCEMENT=off`. Other tools: this text is the enforcement.
+
 ---
 
 ### Session Rule — Never review code you just wrote


### PR DESCRIPTION
## Summary

- **NEW**: `hooks/pre-tool-use` — PreToolUse enforcement hook that mechanically blocks Write/Edit on source code files when no active spec exists in `specs/`
- **MODIFIED**: `install.sh` + `install.ps1` — register PreToolUse hook with `matcher: "Edit|Write"`
- **MODIFIED**: `snippet.md` — Code Rule section documents mechanical enforcement
- **MODIFIED**: `hooks/README.md` — comprehensive enforcement docs (how it works, allowlist, bypass)
- **MODIFIED**: `CHANGELOG.md` + `README.md` — updated

## Design

The hook fires on every Write/Edit tool call. Decision tree:

```
SPEC_FIRST_ENFORCEMENT=off? → allow
.spec-first-bypass exists? → allow
File is not source code? (.md, .json, .yml, config) → allow
File is a test file? (*test*, __tests__) → allow
specs/ has active .md files? → allow
Otherwise → BLOCK (exit 2) with instructions
```

**Source code extensions blocked**: .ts, .tsx, .js, .jsx, .py, .go, .rs, .java, .kt, .rb, .php, .cs, .swift, .c, .cpp, .vue, .svelte, .dart, .ex, .lua, .zig

**Never blocked**: markdown, JSON, YAML, config, test files, spec files, dotfiles

**Bypass**: `touch .spec-first-bypass` (temporary) or `SPEC_FIRST_ENFORCEMENT=off` (env var)

## Test results

| Test | Expected | Result |
|------|----------|--------|
| .md file | allow (0) | ✅ 0 |
| .json config | allow (0) | ✅ 0 |
| test file | allow (0) | ✅ 0 |
| spec file | allow (0) | ✅ 0 |
| .css file | allow (0) | ✅ 0 |
| .ts no spec | block (2) | ✅ 2 |
| .py no spec | block (2) | ✅ 2 |
| .ts with spec | allow (0) | ✅ 0 |
| bypass file | allow (0) | ✅ 0 |
| env=off | allow (0) | ✅ 0 |

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic enforcement that blocks code modifications on source files when no specification exists in the project.
  * Included bypass mechanisms via environment variable or project override file for workflow flexibility.

* **Documentation**
  * Expanded documentation covering the spec-first enforcement scope, installation details, and bypass procedures across multiple reference guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->