### PR TITLE
docs: add lightweight runtime guidance for OMX and OMC

### DIFF
--- a/advanced/deep-dives/tooling/omc-headless-defer-analysis.md
+++ b/advanced/deep-dives/tooling/omc-headless-defer-analysis.md
@@ -1,0 +1,122 @@
+# Spec Note: TOOL-OMC — Headless Mode Analysis (Deferred)
+
+Author: Codex + production learnings  
+Updated: 2026-04-06  
+Status: Deferred / research-backed
+
+---
+
+## Summary
+
+OMC is **not** equivalent to OMX in how easily it can be made headless.
+
+The developer desire is clear:
+
+- keep the intelligence
+- remove tmux/HUD launcher UI
+- make `claude` and `prox` feel lightweight
+
+This is achievable only partially with shell wrappers today. A full solution requires dedicated OMC headless work.
+
+---
+
+## Why OMC Is Harder Than OMX
+
+OMC’s value is more tightly coupled to runtime hooks and session bootstrap:
+
+- session-start hook
+- persistent mode restore
+- keyword detector / skill routing
+- pre-tool-use and post-tool-use interception
+- notepad/context injection
+- stateful orchestration in `.omc/state`
+
+Unlike OMX, much of this intelligence appears to depend on entering the managed runtime path rather than merely having a config file loaded by the host CLI.
+
+---
+
+## Current Best Practical Setup
+
+### Default path
+
+Use native Claude for:
+
+- `claude`
+- `claude --resume <id>`
+- `prox`
+- `prox --resume <id>`
+
+### Explicit OMC path
+
+Keep only as advanced route:
+
+- `claude-omc`
+- `prox-omc`
+- `claude-tmux`
+- `prox-tmux`
+
+This gives:
+
+- lightweight default UX
+- minimal CPU overhead
+- explicit access to OMC orchestration when truly needed
+
+---
+
+## What Is Lost In Native Claude Path
+
+Potentially lost or reduced:
+
+- full session-start restore semantics
+- some persistent-mode lifecycle behavior
+- hook-based skill orchestration
+- OMC-specific HUD/background runtime context
+
+This is the core reason OMC cannot yet be considered “fully merged” into native Claude in the same way OMX is largely merged into native Codex.
+
+---
+
+## What A Future Headless OMC Would Need
+
+To be worth doing, a true headless OMC mode should:
+
+1. Run native Claude binary directly
+2. Still execute:
+   - session-start logic
+   - persistent mode restore
+   - skill/keyword routing
+   - state/notepad context injection
+3. Skip:
+   - tmux HUD
+   - detached panes
+   - launch-time UI takeover
+
+---
+
+## Recommendation
+
+### Do now
+
+- keep native `claude` / `prox` as default
+- keep explicit `claude-omc` / `prox-omc` as advanced route
+
+### Do later
+
+- design and implement a first-class OMC headless runtime
+
+### Do not do now
+
+- do not restore `omc launch` as the default surface
+- do not reintroduce tmux/HUD behavior into ordinary `claude` / `prox`
+
+---
+
+## Definition of Success for Future Work
+
+Future OMC headless mode is successful only if:
+
+- native Claude remains the visible UI
+- OMC runtime intelligence still applies
+- no detached tmux sessions appear during normal launch/resume
+- proxy mode remains compatible
+

--- a/advanced/deep-dives/tooling/omx-headless-native-integration.md
+++ b/advanced/deep-dives/tooling/omx-headless-native-integration.md
@@ -1,0 +1,299 @@
+# Spec: TOOL-OMX — Headless Native Integration for Codex
+
+Author: Codex + production learnings  
+Updated: 2026-04-06  
+Status: Proposed / implementation-aligned
+
+---
+
+## Scope Routing
+
+Error states: 6 → RECOMMEND REVIEW  
+Integration points: 4 → REVIEW REQUIRED  
+High-risk: YES (developer tooling, runtime shell wrappers, session lifecycle, local state)  
+→ Decision: **REVIEW REQUIRED**
+
+---
+
+## Context
+
+The current developer setup uses three overlapping layers:
+
+1. Native Codex CLI (`codex`)
+2. OMX launch/orchestration surface (`omx launch`, `omx resume`)
+3. OMX backend intelligence:
+   - state
+   - memory
+   - code intelligence
+   - trace
+   - optional tmux team runtime
+
+Historically, the launch surface defaulted to tmux/HUD-oriented behavior when not already inside tmux. In practice, this produced:
+
+- detached tmux session storms
+- copy/select pain
+- high CPU usage from many idle tmux sessions
+- confusing `resume` behavior
+
+The goal of this spec is to **preserve OMX intelligence while removing the default dependency on tmux UI**.
+
+---
+
+## Problem Statement
+
+The problem is **not** OMX intelligence itself. The problem is that launch-time UI/runtime behavior is coupled too tightly to the default invocation path.
+
+Observed failure mode:
+
+- `codex resume <id>` or `omx launch ...`
+- launcher resolves detached tmux path
+- repeated detached sessions like `omx-<user>-detached-*` are created
+- tmux CPU rises because many sessions remain alive
+- user sees “green bars” / pane clutter and assumes Codex itself is broken
+
+The production insight is:
+
+> For daily use, most value comes from OMX backend intelligence, not from the tmux/HUD launch layer.
+
+---
+
+## Product Goal
+
+The default developer experience should be:
+
+- lightweight
+- native terminal UI
+- no detached tmux session creation
+- still backed by OMX intelligence wherever possible
+
+Desired daily commands:
+
+- `codex`
+- `codex resume <id>`
+
+Optional advanced surfaces:
+
+- `omx explore`
+- `omx sparkshell`
+- `omx session`
+- `omx ask`
+- `omx team` (explicit only)
+
+---
+
+## Current Architecture
+
+### Native CLI path
+
+`codex` binary:
+- stable
+- copy-friendly
+- no tmux UI
+
+### OMX launch path
+
+`omx launch` and `omx resume` currently go through:
+
+- `resolveCodexLaunchPolicy()`
+- `preLaunch()`
+- `runCodex()`
+- optional HUD/tmux bootstrap
+
+This path owns:
+- overlay generation
+- session lifecycle
+- orphan cleanup
+- notify fallback watcher bootstrap
+
+### OMX backend intelligence
+
+The most valuable intelligence lives outside the tmux UI layer:
+
+- MCP state server
+- MCP memory server
+- MCP code intelligence server
+- MCP trace server
+- optional team runtime server
+- AGENTS/runtime overlay design
+- `explore` / `sparkshell` / `session` command family
+
+---
+
+## What We Learned
+
+### L1 — Codex can keep most OMX intelligence without `omx launch`
+
+Codex still benefits from local `.codex` configuration and MCP servers even when launched natively.
+
+Therefore:
+
+- native Codex keeps most useful OMX power
+- tmux/HUD is not required for the majority of developer workflows
+
+### L2 — Detached tmux should be opt-in, never default
+
+Detached tmux should be reserved for:
+
+- explicit team mode
+- explicit tmux mode
+- long-running pane orchestration
+
+It should not be the silent default for launch/resume.
+
+### L3 — Team MCP is optional overhead for non-team users
+
+If the developer is not actively using tmux workers or team orchestration, `omx_team_run` is mostly overhead.
+
+Therefore:
+
+- state/memory/code-intel/trace should remain enabled
+- team runtime should be disabled by default unless explicitly needed
+
+### L4 — “Launcher intelligence” and “backend intelligence” are different
+
+We should distinguish:
+
+1. Launcher intelligence:
+   - overlay bootstrap
+   - HUD
+   - tmux attachment
+   - prompt injection workarounds
+
+2. Backend intelligence:
+   - memory/state/code-intel/trace
+   - explore/sparkshell/session
+   - toolchain context and orchestration assets
+
+The first can be reduced. The second is the real moat.
+
+---
+
+## Proposed Architecture
+
+### Default path
+
+Use native Codex CLI as the default command surface.
+
+```sh
+codex "$@"
+codex resume <id>
+```
+
+### Explicit OMX path
+
+Keep OMX as an explicit advanced tool.
+
+```sh
+codex-omx ...
+codex-tmux ...
+omx explore ...
+omx sparkshell ...
+omx team ...
+```
+
+### Shell wrapper rule
+
+If `omx` itself is called with launch-like commands:
+
+- `launch`
+- `resume`
+- or empty command
+
+force:
+
+- `TMUX=""`
+- `OMX_LAUNCH_POLICY="direct"`
+
+This preserves OMX behavior while preventing accidental tmux UI spawning.
+
+### Local config rule
+
+Keep enabled:
+
+- `omx_state`
+- `omx_memory`
+- `omx_code_intel`
+- `omx_trace`
+
+Disable by default unless needed:
+
+- `omx_team_run`
+
+---
+
+## UX Principles
+
+### P1 — Default should be invisible
+
+Most users should never think about HUD panes, tmux sessions, or helper bootstrap.
+
+### P2 — Power should remain accessible
+
+Advanced users can still opt into:
+
+- explore
+- sparkshell
+- team
+- session search
+
+### P3 — Failure modes must be local and obvious
+
+If tmux orchestration is intentionally invoked and fails:
+
+- it should fail inside the explicit tmux route
+- not infect ordinary `codex` usage
+
+---
+
+## Implementation Guidance
+
+### Local shell layer
+
+Preferred command structure:
+
+```sh
+codex() { /opt/homebrew/bin/codex "$@"; }
+codex-omx() { TMUX="" CMUX_SURFACE_ID="omx-copy" OMX_LAUNCH_POLICY="direct" omx launch "$@"; }
+codex-tmux() { omx launch "$@"; }
+```
+
+### OMX wrapper itself
+
+`omx()` should force `direct` for launch-like commands:
+
+```sh
+case "$1" in
+  launch|resume|"")
+    TMUX="" OMX_LAUNCH_POLICY="direct" node .../omx.js "$@"
+    ;;
+  *)
+    node .../omx.js "$@"
+    ;;
+esac
+```
+
+### MCP config
+
+Disable `omx_team_run` by default unless an explicit team workflow is being used.
+
+---
+
+## Definition of Done
+
+The setup is considered complete when:
+
+- `codex` launches native CLI directly
+- `codex resume <id>` does not create detached tmux sessions
+- `omx launch` also defaults to direct/no-tmux path
+- no runaway `omx-*-detached-*` sessions are created during normal usage
+- state/memory/code-intel/trace remain available
+- team runtime is opt-in
+
+---
+
+## Follow-up Questions
+
+1. Should OMX upstream expose a first-class `--headless` launch mode?
+2. Should direct native launch still run overlay/session bootstrap in a lighter mode?
+3. Should `omx_team_run` be lazily started only on first explicit `team` usage?
+

--- a/advanced/deep-dives/tooling/runtime-lightweight-agent-integration.md
+++ b/advanced/deep-dives/tooling/runtime-lightweight-agent-integration.md
@@ -1,0 +1,471 @@
+# Spec: TOOL-RUNTIME — Lightweight Native Integration for Codex-LB, Claude Proxy, OMX, and OMC
+
+Author: Codex + local production learnings  
+Updated: 2026-04-06  
+Status: Proposed / spec-first runtime direction
+
+---
+
+## Scope Routing
+
+Error states: 8 → REVIEW REQUIRED  
+Integration points: 6 → REVIEW REQUIRED  
+High-risk: YES (developer runtime, shell wrappers, tmux/session lifecycle, local auth, MCP backend)  
+→ Decision: **REVIEW REQUIRED**
+
+---
+
+## Why This Spec Exists
+
+The current developer environment combines four powerful but overlapping layers:
+
+1. `codex-lb` via native Codex CLI
+2. Claude native CLI
+3. `oh-my-codex` (OMX)
+4. `oh-my-claude-sisyphus` (OMC)
+
+Over time, the environment accumulated two contradictory goals:
+
+- keep the orchestration intelligence, memory, tracing, and helper tooling
+- keep the daily UI path lightweight, copy-friendly, and free of tmux/HUD overhead
+
+In practice, the launch UI layers of OMX/OMC became the main source of pain:
+
+- runaway detached tmux sessions
+- high tmux CPU usage
+- many green panes / pane storms
+- resume paths that feel opaque or broken
+- launch-time behavior that is heavier than the value it provides for daily work
+
+This spec captures the learning:
+
+> The correct long-term architecture is **native UI by default, orchestration intelligence behind it, tmux only as an explicit opt-in surface**.
+
+---
+
+## Product Goal
+
+### Daily experience
+
+The user should mostly live in exactly three commands:
+
+- `codex`
+- `claude`
+- `prox`
+
+These commands should be:
+
+- native
+- lightweight
+- no tmux HUD
+- no detached session storms
+- safe to use for normal launch and resume
+
+### Power path
+
+Advanced users should still have access to:
+
+- `omx explore`
+- `omx sparkshell`
+- `omx session`
+- `omx team`
+- `omc` explicit bridge/orchestration commands
+
+### Architectural principle
+
+The user should be able to say:
+
+> “I keep the intelligence, but I do not pay for the launch UI.”
+
+---
+
+## System Layers
+
+### Layer A — Native terminal UI
+
+These are the user-facing shells that should remain default:
+
+- native Codex binary
+- native Claude binary
+- native Claude binary with proxy env
+
+This layer optimizes for:
+
+- low CPU
+- predictable copy/select behavior
+- fewer moving parts
+- direct and transparent runtime behavior
+
+### Layer B — Orchestration intelligence
+
+This is the real moat and should be preserved:
+
+#### OMX backend intelligence
+
+- MCP state
+- MCP memory
+- MCP code intelligence
+- MCP trace
+- optional team runtime
+- runtime overlay generation
+- `explore`, `sparkshell`, `session`, `agents`, `team`
+
+#### OMC backend intelligence
+
+- session-start hook
+- persistent mode restore
+- keyword detector / skill activation
+- pre-tool-use / post-tool-use lifecycle
+- `.omc/state` orchestration
+- bridge-level runtime semantics
+
+### Layer C — Launcher UI / orchestration surface
+
+This includes:
+
+- tmux HUD
+- detached tmux launch path
+- pane splitting
+- session bootstrap visuals
+- launch-time takeover behavior
+
+This is where the current pain lives.
+
+---
+
+## Current Reality
+
+## Codex + OMX
+
+### What is already true
+
+OMX intelligence is already more separable from its UI than OMC:
+
+- Codex reads `.codex/config.toml`
+- OMX MCP servers can remain active regardless of tmux HUD
+- the most valuable features are not the launch UI itself
+
+### What failed historically
+
+The default OMX launch path could choose detached tmux behavior when not already in tmux:
+
+- `resolveCodexLaunchPolicy()` → `detached-tmux`
+- detached `omx-<user>-detached-*` sessions spawned
+- many sessions stayed alive
+- tmux CPU grew
+
+### What we learned
+
+The best practical setup for daily Codex usage is:
+
+- native or headless-direct launch
+- full backend intelligence
+- detached tmux only when explicitly requested
+
+## Claude + OMC
+
+### What is different
+
+OMC intelligence is more tightly coupled to its managed launch/runtime path.
+
+The most valuable parts of OMC are not only “configuration”, but also runtime hooks:
+
+- session-start restore
+- persistent-mode state transitions
+- tool interception
+- skill lifecycle
+
+### What we learned
+
+Native Claude is better for lightweight UX, but native Claude alone does not automatically guarantee full OMC intelligence.
+
+Therefore:
+
+- the default path should still be native
+- but OMC headless mode needs separate design work
+
+---
+
+## Key Distinction: Intelligence vs UI
+
+We must stop treating these as the same thing.
+
+### Launcher/UI intelligence
+
+Examples:
+
+- HUD bootstrap
+- tmux pane creation
+- detached session naming
+- mouse scrolling / pane resize hooks
+
+This is not the real value for everyday work.
+
+### Backend/runtime intelligence
+
+Examples:
+
+- memory/state MCPs
+- code-intel MCP
+- session overlays
+- prompt routing
+- hook-based state restore
+- trace and orchestration context
+
+This is the real value worth preserving.
+
+---
+
+## Target Architecture
+
+## Default commands
+
+### Codex
+
+Preferred default:
+
+```sh
+codex "$@"
+codex resume <id>
+```
+
+Internally, this should still be allowed to use OMX backend intelligence, but must not go through tmux HUD by default.
+
+### Claude
+
+Preferred default:
+
+```sh
+claude "$@"
+claude --resume <id>
+prox "$@"
+prox --resume <id>
+```
+
+These must remain native UI commands.
+
+## Explicit advanced commands
+
+### OMX explicit
+
+```sh
+omx explore ...
+omx sparkshell ...
+omx session ...
+omx team ...
+```
+
+### OMC explicit
+
+```sh
+omc ...
+claude-omc ...
+prox-omc ...
+```
+
+These are power-user surfaces, not defaults.
+
+---
+
+## Runtime Rules
+
+### Rule 1 — No detached tmux by default
+
+Launch/resume must never silently choose detached tmux for ordinary use.
+
+### Rule 2 — Headless/direct should be the default for launch-like commands
+
+For launch-like invocations:
+
+- `launch`
+- `resume`
+- or empty launch surface
+
+the runtime should force:
+
+- no inherited tmux attachment
+- no HUD bootstrap
+- no detached session path
+
+### Rule 3 — Team/tmux is explicit only
+
+Team runtime should be:
+
+- off by default
+- enabled only when explicit team behavior is requested
+
+### Rule 4 — Proxy path must remain native
+
+Proxy-backed Claude should stay direct:
+
+- native UI
+- proxy env
+- no launcher UI
+
+### Rule 5 — Intelligence should be composable
+
+The user should be able to combine:
+
+- native binary
+- backend MCP
+- headless launch lifecycle
+
+without being forced into tmux UI.
+
+---
+
+## Practical Local Configuration
+
+### Good current local shape for Codex
+
+Keep enabled:
+
+- `omx_state`
+- `omx_memory`
+- `omx_code_intel`
+- `omx_trace`
+
+Disable unless explicitly needed:
+
+- `omx_team_run`
+
+### Good current local shell wrappers
+
+#### Native-first
+
+```sh
+claude() { /path/to/claude "$@"; }
+prox() { ANTHROPIC_BASE_URL=... ANTHROPIC_AUTH_TOKEN=... /path/to/claude "$@"; }
+```
+
+#### Codex with headless OMX direct path
+
+Two valid strategies exist:
+
+#### Strategy A — fully native Codex default
+
+```sh
+codex() { /path/to/codex "$@"; }
+```
+
+Use when:
+
+- you want maximum simplicity
+- you are okay losing launch-time OMX overlay/lifecycle extras
+
+#### Strategy B — OMX direct/headless default
+
+```sh
+codex() {
+  case "$1" in
+    resume|--resume)
+      shift
+      TMUX="" CMUX_SURFACE_ID="omx-copy" OMX_LAUNCH_POLICY="direct" omx resume "$@"
+      ;;
+    *)
+      TMUX="" CMUX_SURFACE_ID="omx-copy" OMX_LAUNCH_POLICY="direct" omx launch "$@"
+      ;;
+  esac
+}
+```
+
+Use when:
+
+- you want more OMX launch-time intelligence
+- you still want zero tmux UI
+
+This is currently the best “smart but lightweight” shape for Codex.
+
+---
+
+## Why Codex Can Take More OMX Intelligence Than Claude Can Take OMC Intelligence
+
+### Codex + OMX
+
+Codex gains a lot from:
+
+- `.codex/config.toml`
+- active MCP servers
+- OMX runtime overlay
+
+These are more separable from tmux UI.
+
+### Claude + OMC
+
+Claude/OMC depends more heavily on:
+
+- session-start hook execution
+- persistent mode bootstrap
+- lifecycle interception
+
+These are less separable from the OMC runtime today.
+
+Therefore:
+
+- Codex can already absorb most OMX value with low UX cost
+- Claude cannot yet absorb full OMC value without more explicit headless design
+
+---
+
+## Open Design Questions
+
+### Q1 — Should OMX expose a first-class `--headless` or `--no-hud` mode?
+
+Current shell forcing works, but upstream support would be cleaner and safer.
+
+### Q2 — Should native Codex receive a minimal overlay bootstrap automatically?
+
+This would preserve more OMX intelligence even when not using `omx launch`.
+
+### Q3 — Should `omx_team_run` become lazy-init only?
+
+This would reduce background overhead while preserving the team path.
+
+### Q4 — Should OMC support headless runtime hooks without `omc launch`?
+
+This is the key design problem for future work.
+
+---
+
+## Recommended Roadmap
+
+### Phase 1 — Stabilize local default behavior
+
+- native UI by default
+- direct/headless launch policy
+- team runtime disabled by default
+- detached session cleanup
+
+### Phase 2 — Formalize headless OMX
+
+- spec-first `--headless` semantics
+- direct lifecycle path without tmux UI
+- better docs and shell examples
+
+### Phase 3 — Research and prototype headless OMC
+
+- separate runtime hooks from launch UI
+- prove what intelligence is preserved
+- only then consider wider rollout
+
+---
+
+## Definition of Done
+
+This tooling direction is complete when:
+
+- `codex`, `claude`, and `prox` are the only daily commands most users need
+- no detached tmux sessions are created by default usage
+- Codex still benefits from OMX backend intelligence
+- Claude/proxy remain lightweight without reintroducing OMC launch UI
+- explicit tmux/advanced orchestration remains available as opt-in
+
+---
+
+## Non-Goals
+
+- turning tmux into the default UX again
+- hiding failures behind more launcher complexity
+- binding all intelligence to a single opaque wrapper
+- forcing users to choose between “smart” and “usable”
+


### PR DESCRIPTION
## Summary
- add a comprehensive runtime integration doc for Codex-LB, Claude proxy, OMX, and OMC
- add a focused OMX headless/native integration deep dive
- add a focused OMC headless/defer analysis

## Why
These learnings were originally discovered while stabilizing local runtime behavior in another repo. This PR moves them into spec-first as reusable architecture guidance instead of leaving them trapped in local shell wrappers and issue comments.

## Notes
- docs only
- no product runtime changes in this repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification documents for advanced tooling architecture, including detailed guidance on headless operation modes, native integration patterns for development environments, and foundational design for lightweight agent integration across the platform ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->